### PR TITLE
Support for PHP 5.3+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /tmp
 /navdocs
 /tests/testdata/userData.real.json
+/.idea

--- a/src/NavOnlineInvoice/InvoiceOperations.php
+++ b/src/NavOnlineInvoice/InvoiceOperations.php
@@ -71,11 +71,11 @@ class InvoiceOperations {
         $idx = $this->index;
         $this->index++;
 
-        $this->invoices[] = [
+        $this->invoices[] = array(
             "index" => $idx,
             "operation" => $operation,
             "invoice" => $this->convertXml($xml)
-        ];
+        );
 
         return $idx;
     }

--- a/src/NavOnlineInvoice/QueryInvoiceDataRequestXml.php
+++ b/src/NavOnlineInvoice/QueryInvoiceDataRequestXml.php
@@ -6,7 +6,7 @@ use Exception;
 
 class QueryInvoiceDataRequestXml extends BaseRequestXml {
 
-    private static $queryTypes = ["invoiceQuery", "queryParams"];
+    private static $queryTypes = array("invoiceQuery", "queryParams");
 
 
     function __construct($config, $queryType, $queryData, $page) {

--- a/src/NavOnlineInvoice/XsdValidationError.php
+++ b/src/NavOnlineInvoice/XsdValidationError.php
@@ -8,11 +8,11 @@ class XsdValidationError extends Exception {
 
     protected $errors;
 
-    protected static $levelMap = [
+    protected static $levelMap = array(
         LIBXML_ERR_WARNING => "Warning",
         LIBXML_ERR_ERROR => "Error",
         LIBXML_ERR_FATAL => "Fatal Error"
-    ];
+    );
 
 
     function __construct($errors) {
@@ -28,7 +28,7 @@ class XsdValidationError extends Exception {
 
 
     protected function createErrorMessage() {
-        $messages = [];
+        $messages = array();
 
         foreach ($this->errors as $error) {
             $messages[] = self::$levelMap[$error->level] . ": " . $error->message;


### PR DESCRIPTION
The whole library can run on PHP 5.3 but the short array syntax is not supported yet. Replaced the 4 occurrence of that.