### PR TITLE
PHPDoc fixek + \SimpleXMLElement használata + cleanup

### DIFF
--- a/src/NavOnlineInvoice/BaseExceptionResponse.php
+++ b/src/NavOnlineInvoice/BaseExceptionResponse.php
@@ -24,7 +24,7 @@ abstract class BaseExceptionResponse extends Exception {
 
     /**
      * Return the result field of the XML in array format
-     * @return Array
+     * @return array
      */
     abstract public function getResult();
 

--- a/src/NavOnlineInvoice/BaseRequestXml.php
+++ b/src/NavOnlineInvoice/BaseRequestXml.php
@@ -1,15 +1,16 @@
 <?php
 
 namespace NavOnlineInvoice;
-use SimpleXMLElement;
 
 
 class BaseRequestXml {
 
     protected $rootName;
     protected $config;
-
-    protected $xml;
+	/**
+	 * @var \SimpleXMLElement
+	 */
+	protected $xml;
 
     protected $requestId;
     protected $timestamp;
@@ -18,7 +19,7 @@ class BaseRequestXml {
     /**
      * Request XML készítése
      *
-     * @param String $rootName  Root XML elem neve
+     * @param string $rootName  Root XML elem neve
      * @param Config $config    Konfigurációt tartalmazó objektum
      */
     function __construct($rootName, $config) {
@@ -53,7 +54,7 @@ class BaseRequestXml {
      *
      * Pattern: [+a-zA-Z0-9_]{1,30}
      *
-     * @return String
+     * @return string
      */
     protected function generateRequestId() {
         $id = "RID" . microtime() . mt_rand(10000, 99999);
@@ -66,7 +67,7 @@ class BaseRequestXml {
     /**
      * A kérés kliens oldali időpontja UTC-ben, ezredmásodperccel
      *
-     * @return String
+     * @return string
      */
     protected function getTimestamp() {
         $now = microtime(true);
@@ -77,7 +78,7 @@ class BaseRequestXml {
 
 
     protected function createXmlObject() {
-        $this->xml = new SimpleXMLElement($this->getInitialXmlString());
+        $this->xml = new \SimpleXMLElement($this->getInitialXmlString());
     }
 
 
@@ -164,7 +165,7 @@ class BaseRequestXml {
     /**
      * XML objektum lekérése
      *
-     * @return SimpleXMLElement
+     * @return \SimpleXMLElement
      */
     public function getXML() {
         return $this->xml;
@@ -174,7 +175,7 @@ class BaseRequestXml {
     /**
      * XML adat lekérése string-ként
      *
-     * @return String
+     * @return string
      */
     public function asXML() {
         return $this->xml->asXML();

--- a/src/NavOnlineInvoice/Config.php
+++ b/src/NavOnlineInvoice/Config.php
@@ -14,15 +14,14 @@ class Config {
 
     public $validateApiSchema = false;
     public $apiSchemaFilename;
-
-
-    /**
-     * NavOnlineInvoice Reporter osztály számára szükséges konfigurációs objektum készítése
-     *
-     * @param String       $baseUrl     NAV API URL
-     * @param Array|String $user        User data array vagy json fájlnév
-     * @param Array|String $software    Software data array vagy json fájlnév
-     */
+	/**
+	 * NavOnlineInvoice Reporter osztály számára szükséges konfigurációs objektum készítése
+	 *
+	 * @param string       $baseUrl  NAV API URL
+	 * @param array|string $user     User data array vagy json fájlnév
+	 * @param array|string $software Software data array vagy json fájlnév
+	 * @throws \Exception
+	 */
     function __construct($baseUrl, $user, $software = null) {
 
         $this->apiSchemaFilename = __DIR__ . "/xsd/invoiceApi.xsd";
@@ -59,7 +58,7 @@ class Config {
      * Teszt: https://api-test.onlineszamla.nav.gov.hu/invoiceService
      * Éles: https://api.onlineszamla.nav.gov.hu/invoiceService
      *
-     * @param String $baseUrl  NAV eléréséhez használt környezet
+     * @param string $baseUrl  NAV eléréséhez használt környezet
      */
     public function setBaseUrl($baseUrl) {
         $this->baseUrl = $baseUrl;
@@ -78,7 +77,7 @@ class Config {
 
     /**
      *
-     * @param Array $data
+     * @param array $data
      */
     public function setSoftware($data) {
         $this->software = $data;
@@ -87,7 +86,7 @@ class Config {
 
     /**
      *
-     * @param  String $jsonFile JSON file name
+     * @param  string $jsonFile JSON file name
      */
     public function loadSoftware($jsonFile) {
         $data = $this->loadJsonFile($jsonFile);
@@ -97,7 +96,7 @@ class Config {
 
     /**
      *
-     * @param Array $data
+     * @param array $data
      */
     public function setUser($data) {
         $this->user = $data;
@@ -106,20 +105,19 @@ class Config {
 
     /**
      *
-     * @param  String $jsonFile JSON file name
+     * @param  string $jsonFile JSON file name
      */
     public function loadUser($jsonFile) {
         $data = $this->loadJsonFile($jsonFile);
         $this->setUser($data);
     }
-
-
-    /**
-     * JSON fájl betöltése
-     *
-     * @param  String $jsonFile
-     * @return Array
-     */
+	/**
+	 * JSON fájl betöltése
+	 *
+	 * @param  string $jsonFile
+	 * @return array
+	 * @throws \Exception
+	 */
     protected function loadJsonFile($jsonFile) {
         if (!file_exists($jsonFile)) {
             throw new Exception("A megadott json fájl nem létezik: $jsonFile");

--- a/src/NavOnlineInvoice/Connector.php
+++ b/src/NavOnlineInvoice/Connector.php
@@ -15,14 +15,16 @@ class Connector {
     function __construct($config) {
         $this->config = $config;
     }
-
-
-    /**
-     *
-     * @param  String $url
-     * @param  String|SimpleXMLElement $requestXml
-     * @return SimpleXMLElement
-     */
+	/**
+	 *
+	 * @param  string                   $url
+	 * @param  string|\SimpleXMLElement $requestXml
+	 * @return \SimpleXMLElement
+	 * @throws \NavOnlineInvoice\CurlError
+	 * @throws \NavOnlineInvoice\GeneralErrorResponse
+	 * @throws \NavOnlineInvoice\GeneralExceptionResponse
+	 * @throws \NavOnlineInvoice\HttpResponseError
+	 */
     public function post($url, $requestXml) {
 
         $url = $this->config->baseUrl . $url;

--- a/src/NavOnlineInvoice/GeneralErrorResponse.php
+++ b/src/NavOnlineInvoice/GeneralErrorResponse.php
@@ -1,8 +1,6 @@
 <?php
 
 namespace NavOnlineInvoice;
-use Exception;
-
 
 class GeneralErrorResponse extends BaseExceptionResponse {
 

--- a/src/NavOnlineInvoice/GeneralExceptionResponse.php
+++ b/src/NavOnlineInvoice/GeneralExceptionResponse.php
@@ -1,8 +1,6 @@
 <?php
 
 namespace NavOnlineInvoice;
-use Exception;
-
 
 class GeneralExceptionResponse extends BaseExceptionResponse {
 

--- a/src/NavOnlineInvoice/InvoiceOperations.php
+++ b/src/NavOnlineInvoice/InvoiceOperations.php
@@ -46,16 +46,15 @@ class InvoiceOperations {
     protected function getXsdFilename() {
         return __DIR__ . "/xsd/invoiceData.xsd";
     }
-
-
-    /**
-     * Számla ('szakmai XML') hozzáadása
-     *
-     * @param SimpleXMLElement $xml     Számla adatai (szakmai XML)
-     * @param string $operation         Számlaművelet Enum(CREATE, MODIFY, STORNO, ANNUL)
-     * @return int                      A beszúrt művelet sorszáma (index)
-     */
-    public function add($xml, $operation = "CREATE") {
+	/**
+	 * Számla ('szakmai XML') hozzáadása
+	 *
+	 * @param \SimpleXMLElement $xml       Számla adatai (szakmai XML)
+	 * @param string            $operation Számlaművelet Enum(CREATE, MODIFY, STORNO, ANNUL)
+	 * @return int                      A beszúrt művelet sorszáma (index)
+	 * @throws \Exception
+	 */
+    public function add(\SimpleXMLElement $xml, $operation = "CREATE") {
 
         // XSD validálás
         if ($this->schemaValidation) {
@@ -89,12 +88,12 @@ class InvoiceOperations {
     public function getInvoices() {
         return $this->invoices;
     }
-
-
-    /**
-     * XML objektum konvertálása base64-es szöveggé
-     */
-    protected function convertXml($xml) {
+	/**
+	 * XML objektum konvertálása base64-es szöveggé
+	 * @param \SimpleXMLElement $xml
+	 * @return string
+	 */
+    protected function convertXml(\SimpleXMLElement $xml) {
         $xml = $xml->asXML();
         return base64_encode($xml);
     }

--- a/src/NavOnlineInvoice/ManageInvoiceRequestXml.php
+++ b/src/NavOnlineInvoice/ManageInvoiceRequestXml.php
@@ -12,7 +12,7 @@ class ManageInvoiceRequestXml extends BaseRequestXml {
     /**
      * @param Config $config
      * @param InvoiceOperations $invoiceOperations
-     * @param String $token
+     * @param string $token
      */
     function __construct($config, $invoiceOperations, $token) {
         $this->invoiceOperations = $invoiceOperations;

--- a/src/NavOnlineInvoice/QueryInvoiceDataRequestXml.php
+++ b/src/NavOnlineInvoice/QueryInvoiceDataRequestXml.php
@@ -7,9 +7,15 @@ use Exception;
 class QueryInvoiceDataRequestXml extends BaseRequestXml {
 
     private static $queryTypes = array("invoiceQuery", "queryParams");
-
-
-    function __construct($config, $queryType, $queryData, $page) {
+	/**
+	 * QueryInvoiceDataRequestXml constructor.
+	 * @param $config
+	 * @param $queryType
+	 * @param $queryData
+	 * @param $page
+	 * @throws \Exception
+	 */
+	function __construct($config, $queryType, $queryData, $page) {
         if (!in_array($queryType, self::$queryTypes)) {
             throw new Exception("Érvénytelen queryType: $queryType");
         }
@@ -25,7 +31,7 @@ class QueryInvoiceDataRequestXml extends BaseRequestXml {
     }
 
 
-    protected function addQueryData($xmlNode, $type, $data) {
+    protected function addQueryData(\SimpleXMLElement $xmlNode, $type, $data) {
         $node = $xmlNode->addChild($type);
 
         foreach ($data as $key => $value) {

--- a/src/NavOnlineInvoice/Reporter.php
+++ b/src/NavOnlineInvoice/Reporter.php
@@ -1,8 +1,6 @@
 <?php
 
 namespace NavOnlineInvoice;
-use Exception;
-
 
 class Reporter {
 
@@ -29,7 +27,7 @@ class Reporter {
      * NAV részére beküldeni.
      *
      * @param  InvoiceOperations $invoiceOperations
-     * @return String            $transactionId
+     * @return string            $transactionId
      */
     public function manageInvoice($invoiceOperations) {
         $token = $this->tokenExchange();
@@ -47,12 +45,12 @@ class Reporter {
      * A /queryInvoiceData a számla adatszolgáltatások lekérdezésére szolgáló operáció. A lekérdezés
      * történhet konkrét számla sorszámra, vagy lekérdezési paraméterek alapján.
      *
-     * @param  String            $queryType     A queryType értéke lehet 'invoiceQuery' vagy 'queryParams'
+     * @param  string            $queryType     A queryType értéke lehet 'invoiceQuery' vagy 'queryParams'
      *                                          függően attól, hogy konktér számla sorszámot, vagy általános
      *                                          lekérdezési paramétereket adunk át.
-     * @param  Array             $queryData     A queryType-nak megfelelően összeállított lekérdezési adatok
+     * @param  array             $queryData     A queryType-nak megfelelően összeállított lekérdezési adatok
      * @param  Int               $page          Oldalszám (1-től kezdve a számozást)
-     * @return SimpleXMLElement  $responseXml   A teljes visszakapott XML, melyből a 'queryResults' elem releváns
+     * @return \SimpleXMLElement  $responseXml   A teljes visszakapott XML, melyből a 'queryResults' elem releváns
      */
     public function queryInvoiceData($queryType, $queryData, $page = 1) {
         $requestXml = new QueryInvoiceDataRequestXml($this->config, $queryType, $queryData, $page);
@@ -68,9 +66,9 @@ class Reporter {
      * A /queryInvoiceStatus a számla adatszolgáltatás feldolgozás aktuális állapotának és eredményének
      * lekérdezésére szolgáló operáció.
      *
-     * @param  String  $transactionId
+     * @param  string  $transactionId
      * @param  boolean $returnOriginalRequest
-     * @return SimpleXMLElement  $responseXml    A teljes visszakapott XML, melyből a 'processingResults' elem releváns
+     * @return \SimpleXMLElement  $responseXml    A teljes visszakapott XML, melyből a 'processingResults' elem releváns
      */
     public function queryInvoiceStatus($transactionId, $returnOriginalRequest = false) {
         $requestXml = new QueryInvoiceStatusRequestXml($this->config, $transactionId, $returnOriginalRequest);
@@ -86,8 +84,8 @@ class Reporter {
      * A /queryTaxpayer belföldi adószám validáló operáció, mely a számlakiállítás folyamatába építve képes
      * a megadott adószám valódiságáról és érvényességéről a NAV adatbázisa alapján adatot szolgáltatni.
      *
-     * @param  String $taxNumber            Adószám, pattern: [0-9]{8}
-     * @return Boolean|SimpleXMLElement     Invalid adószám esetén `false` a visszatérési érték, valid adószám estén
+     * @param  string $taxNumber            Adószám, pattern: [0-9]{8}
+     * @return Boolean|\SimpleXMLElement     Invalid adószám esetén `false` a visszatérési érték, valid adószám estén
      *                                      pedig a válasz XML taxpayerData része (SimpleXMLElement), mely a nevet és címadatokat tartalmazza
      */
     public function queryTaxpayer($taxNumber) {
@@ -113,7 +111,7 @@ class Reporter {
      * Megjegyzés: csak a token kerül visszaadásra, az érvényességi idő nem. Ennek oka, hogy a tokent csak egy kéréshez (egyszer) lehet használni
      * NAV fórumon elhangzottak alapján (megerősítés szükséges!), és ez az egyszeri felhasználás azonnal megtörténik a token lekérése után (manageInvoice hívás).
      *
-     * @return String       Token
+     * @return string       Token
      */
     public function tokenExchange() {
         $requestXml = new TokenExchangeRequestXml($this->config);

--- a/src/NavOnlineInvoice/Xsd.php
+++ b/src/NavOnlineInvoice/Xsd.php
@@ -5,14 +5,14 @@ use DOMDocument;
 
 
 class Xsd {
-
-    /**
-     * A megadott XML-t (string) ellenőrzi a megadott XSD sémával.
-     * Hiba esetén XsdValidationError exception-t dob.
-     *
-     * @param  String $xmlString
-     * @param  String $xsdFilename
-     */
+	/**
+	 * A megadott XML-t (string) ellenőrzi a megadott XSD sémával.
+	 * Hiba esetén XsdValidationError exception-t dob.
+	 *
+	 * @param  string $xmlString
+	 * @param  string $xsdFilename
+	 * @throws \NavOnlineInvoice\XsdValidationError
+	 */
     public static function validate($xmlString, $xsdFilename) {
         $doc = new DOMDocument();
         $doc->loadXML($xmlString);


### PR DESCRIPTION
- throws sorok hozzáadva a PHPDoc blokkhoz, ahol a függvény kivételt dob
- use Exception eltávolítása, ahol volt, mivel semmi nem használja
- primitív típusok nevének javítása PHPDoc blokkokban: https://docs.phpdoc.org/guides/types.html
- SimpleXMLElement közvetlen hivatkozása a globális névtérből (use eltávolítása ezzel együtt)
- néhány függvény esetén PHPDoc blokk generálása, ami segíti a fejlettebb IDEk esetén a működésének megértését