### PR TITLE
Egyedi RequestId generálás, naplózás bővítése

### DIFF
--- a/src/NavOnlineInvoice/BaseRequestXml.php
+++ b/src/NavOnlineInvoice/BaseRequestXml.php
@@ -31,36 +31,13 @@ abstract class BaseRequestXml {
 
 
     protected function createXml() {
-        $this->requestId = $this->generateRequestId();
+        $this->requestId = $this->config->getRequestIdGenerator()->generate();
         $this->timestamp = $this->getTimestamp();
 
         $this->createXmlObject();
         $this->addHeader();
         $this->addUser();
         $this->addSoftware();
-    }
-
-
-    /**
-     * Egyedi request ID generálása
-     *
-     * NAV specifikáció:
-     * A requestId a kérés azonosítója. Értéke bármi lehet, ami a pattern szerint érvényes és az
-     * egyediséget nem sérti. A requestId-nak - az adott adózó vonatkozásában - kérésenként
-     * egyedinek kell lennie. Az egyediségbe csak a sikeresen feldolgozott kérések számítanak bele, a
-     * sikertelen vagy a szerver által elutasított kérések azonosítói nem, azok az első sikeres
-     * tranzakcióig (HTTP 200-as válaszig) újra felhasználhatóak. A tag értéke beleszámít a
-     * requestSignature értékébe.
-     *
-     * Pattern: [+a-zA-Z0-9_]{1,30}
-     *
-     * @return string
-     */
-    protected function generateRequestId() {
-        $id = "RID" . microtime() . mt_rand(10000, 99999);
-        $id = preg_replace("/[^A-Z0-9]/", "", $id);
-        $id = substr($id, 0, 30);
-        return $id;
     }
 
 
@@ -194,6 +171,11 @@ abstract class BaseRequestXml {
      */
     public function validateSchema() {
         Xsd::validate($this->asXML(), Config::getApiXsdFilename());
+    }
+
+    public function getRequestId()
+    {
+        return $this->requestId;
     }
 
 }

--- a/src/NavOnlineInvoice/Config.php
+++ b/src/NavOnlineInvoice/Config.php
@@ -16,6 +16,8 @@ class Config {
 
     public $curlTimeout = null;
 
+    /** @var RequestIdGeneratorInterface */
+    public $requestIdGenerator;
 
     /**
      * NavOnlineInvoice Reporter osztály számára szükséges konfigurációs objektum készítése
@@ -52,6 +54,18 @@ class Config {
         } else {
             $this->setSoftware($software);
         }
+
+        $this->setRequestIdGenerator(new RequestIdGeneratorBasic());
+    }
+
+    function setRequestIdGenerator(RequestIdGeneratorInterface $obj)
+    {
+        $this->requestIdGenerator = $obj;
+    }
+
+    function getRequestIdGenerator()
+    {
+        return $this->requestIdGenerator;
     }
 
 

--- a/src/NavOnlineInvoice/Connector.php
+++ b/src/NavOnlineInvoice/Connector.php
@@ -10,6 +10,7 @@ class Connector {
     private $lastRequestUrl = null;
     private $lastRequestBody = null;
     private $lastResponseBody = null;
+    private $lastRequestId = null;
 
 
     /**
@@ -25,6 +26,7 @@ class Connector {
         $this->lastRequestUrl = null;
         $this->lastRequestBody = null;
         $this->lastResponseBody = null;
+        $this->lastRequestId = null;
     }
 
 
@@ -38,6 +40,7 @@ class Connector {
             'requestUrl' => $this->lastRequestUrl,
             'requestBody' => $this->lastRequestBody,
             'responseBody' => $this->lastResponseBody,
+            'lastRequestId' => $this->lastRequestId
         );
     }
 
@@ -60,6 +63,8 @@ class Connector {
 
         $xmlString = is_string($requestXml) ? $requestXml : $requestXml->asXML();
         $this->lastRequestBody = $xmlString;
+
+        $this->lastRequestId = $requestXml instanceof BaseRequestXml ? $requestXml->getRequestId() : null;
 
         if ($this->config->validateApiSchema) {
             Xsd::validate($xmlString, Config::getApiXsdFilename());

--- a/src/NavOnlineInvoice/RequestIdGeneratorBasic.php
+++ b/src/NavOnlineInvoice/RequestIdGeneratorBasic.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace NavOnlineInvoice;
+
+class RequestIdGeneratorBasic implements RequestIdGeneratorInterface
+{
+    /**
+     * Egyedi request ID generálása
+     *
+     * NAV specifikáció:
+     * A requestId a kérés azonosítója. Értéke bármi lehet, ami a pattern szerint érvényes és az
+     * egyediséget nem sérti. A requestId-nak - az adott adózó vonatkozásában - kérésenként
+     * egyedinek kell lennie. Az egyediségbe csak a sikeresen feldolgozott kérések számítanak bele, a
+     * sikertelen vagy a szerver által elutasított kérések azonosítói nem, azok az első sikeres
+     * tranzakcióig (HTTP 200-as válaszig) újra felhasználhatóak. A tag értéke beleszámít a
+     * requestSignature értékébe.
+     *
+     * Pattern: [+a-zA-Z0-9_]{1,30}
+     *
+     * @return string
+     */
+    function generate() {
+        $id = "RID" . microtime() . mt_rand(10000, 99999);
+        $id = preg_replace("/[^A-Z0-9]/", "", $id);
+        $id = substr($id, 0, 30);
+        return $id;
+    }
+
+}

--- a/src/NavOnlineInvoice/RequestIdGeneratorInterface.php
+++ b/src/NavOnlineInvoice/RequestIdGeneratorInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace NavOnlineInvoice;
+
+interface RequestIdGeneratorInterface
+{
+    function generate();
+}


### PR DESCRIPTION
A RequestID generálást most egy fixen beállított függvény végzi ezen szeretnék javítani ezért egy interface-t vezettem be. Így akár saját adatbázisban lehetőség van a request id egyediségét biztosítani a config létrehozása során `$config->setRequestIdGenerator(new RequestIdGeneratorSql());`

Valamint a naplózást segítendő ezt az azonosítót beraktam a `getLastRequestData()` hívás eredményébe, amennyiben ki tudja nyerni.