### PR TITLE
Authentikáció már hashelt jelszóval

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Technikai felhasználó és szoftver adatok beállítása, Reporter példány l�
 $userData = array(
     "login" => "username",
     "password" => "password",
-    "passwordHash" => "...",    // Opcionális, a jelszó már SHA512 hashelt változata. Amennyiben létezik ezt, az authentikáció már ezzel történik
+//  "passwordHash" => "...",    // Opcionális, a jelszó már SHA512 hashelt változata. Amennyiben létezik ez a változó, akkor az authentikáció során ezt használja
     "taxNumber" => "12345678",
     "signKey" => "sign-key",
     "exchangeKey" => "exchange-key",

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Technikai felhasználó és szoftver adatok beállítása, Reporter példány l�
 $userData = array(
     "login" => "username",
     "password" => "password",
+    "passwordHash" => "...",    // Opcionális, a jelszó már SHA512 hashelt változata. Amennyiben létezik ezt, az authentikáció már ezzel történik
     "taxNumber" => "12345678",
     "signKey" => "sign-key",
     "exchangeKey" => "exchange-key",

--- a/src/NavOnlineInvoice/BaseRequestXml.php
+++ b/src/NavOnlineInvoice/BaseRequestXml.php
@@ -83,7 +83,7 @@ abstract class BaseRequestXml {
     protected function addUser() {
         $user = $this->xml->addChild("user");
 
-        $passwordHash = Util::sha512($this->config->user["password"]);
+        $passwordHash = isset($this->config->user["passwordHash"]) ? $this->config->user["passwordHash"] : Util::sha512($this->config->user["password"]);
         $signature = $this->getRequestSignatureHash();
 
         $user->addChild("login", $this->config->user["login"]);


### PR DESCRIPTION
Szükségünk volt egy olyan lehetőségre, hogy ne a jelszót magát adjuk meg, hanem a már hashelt változatát. Ez a pull request ennek a megvalósítása, talán másoknak is szüksége lehet rá később.

A userData passwordHash változója opcionális, ennél jobb megoldást nem tudtam kitalálni hirtelen.