### PR TITLE
Avoid PHP 8.1 deprecation warning in BaseRequestXml.php:57

### DIFF
--- a/src/NavOnlineInvoice/BaseRequestXml.php
+++ b/src/NavOnlineInvoice/BaseRequestXml.php
@@ -54,7 +54,7 @@ abstract class BaseRequestXml {
         $milliseconds = round(($now - floor($now)) * 1000);
         $milliseconds = min($milliseconds, 999);
 
-        return gmdate("Y-m-d\TH:i:s", $now) . sprintf(".%03dZ", $milliseconds);
+        return gmdate("Y-m-d\TH:i:s", (int) $now) . sprintf(".%03dZ", $milliseconds);
     }
 
 


### PR DESCRIPTION
I noticed the following message when I run a technical annulment:
```
Deprecated: Implicit conversion from float 1643214619.570649 to int loses precision in /var/www/html/vendor/pzs/nav-online-invoice/src/NavOnlineInvoice/BaseRequestXml.php on line 57
```
More details about the deprication:
https://php.watch/versions/8.1/deprecate-implicit-conversion-incompatible-float-string

So will suggest here an explicit int casting.